### PR TITLE
Only aggregations

### DIFF
--- a/notebooks/dask.ipynb
+++ b/notebooks/dask.ipynb
@@ -9,11 +9,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-01-13T14:21:06.690430Z",
-     "start_time": "2020-01-13T14:20:54.182849Z"
+     "end_time": "2020-01-23T15:09:08.297384Z",
+     "start_time": "2020-01-23T15:09:08.294237Z"
     },
     "code_folding": [
      0
@@ -22,16 +22,22 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "!pip install -U pip dask numpy fsspec>=0.3.3 tqdm pyarrow"
+    "!pip install -U pip dask numpy fsspec>=0.3.3 tqdm pyarrow\n",
+    "!pip install pyarrow==0.15"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "execution_count": 2,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-01-23T18:43:00.952976Z",
+     "start_time": "2020-01-23T18:43:00.950954Z"
+    }
+   },
    "outputs": [],
    "source": [
-    "!aws s3 cp --recursive s3://xdss-public-datasets/demos/taxi_parquet ../datasets/taxi_parquet"
+    "#!aws s3 cp --recursive s3://xdss-public-datasets/demos/taxi_parquet ../datasets/taxi_parquet"
    ]
   },
   {
@@ -39,7 +45,8 @@
    "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
-     "start_time": "2020-01-13T15:34:54.417Z"
+     "end_time": "2020-01-23T18:48:40.295921Z",
+     "start_time": "2020-01-23T18:48:39.765041Z"
     }
    },
    "outputs": [
@@ -57,8 +64,9 @@
     "from src.dask_utils import *\n",
     "from src.config import repetitions\n",
     "\n",
-    "name = 'dask'\n",
-    "data_path = '../datasets/taxi_parquet'\n",
+    "use_parquet = False\n",
+    "name = 'dask-parquet' if use_parquet else 'dask-vaex-hdf5'\n",
+    "data_path = '/data/taxi_parquet/' if use_parquet else '/data/yellow_taxi_2009_2015_f32.hdf5'\n",
     "results_path = f\"../results/{name}_1b.csv\"\n",
     "benchmarks = {}\n",
     "print(f\"test for {repetitions} repetitions\")"
@@ -73,11 +81,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-01-14T10:43:20.651711Z",
-     "start_time": "2020-01-14T10:42:16.428926Z"
+     "end_time": "2020-01-23T18:48:41.026110Z",
+     "start_time": "2020-01-23T18:48:40.297338Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Load data\n",
+    "def read_file(df, data_path):\n",
+    "    if use_parquet:\n",
+    "        data = read_file_parquet(None, data_path)\n",
+    "        # we don't need to add those right?\n",
+    "        # data.pickup_datetime = dd.to_datetime(data.pickup_datetime)\n",
+    "        # data['pickup_hour'] = data.pickup_datetime.dt.hour\n",
+    "        # data = data.set_index('passenger_count')\n",
+    "    else:\n",
+    "        column_names = ['fare_amount', 'tip_amount', 'trip_distance', 'pickup_longitude', 'pickup_latitude', 'dropoff_longitude', 'dropoff_latitude']\n",
+    "        data = read_file_vaex(None, data_path, chunksize=10_000_000, column_names=column_names)\n",
+    "    return data\n",
+    "data = read_file(None, data_path)\n",
+    "# no index is better, just leave the order as it is\n",
+    "# data.set_index('passenger_count')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-01-23T18:49:00.819361Z",
+     "start_time": "2020-01-23T18:48:41.027924Z"
     }
    },
    "outputs": [
@@ -85,17 +121,147 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "size: 1173057928 with 18 columns\n"
+      "size: 1173057927 with 8 columns\n"
      ]
     }
    ],
    "source": [
-    "# Load data\n",
-    "data = read_file(None, data_path)\n",
-    "# data.pickup_datetime = dd.to_datetime(data.pickup_datetime)\n",
-    "# data['pickup_hour'] = data.pickup_datetime.dt.hour\n",
-    "# data = data.set_index('passenger_count')\n",
     "print(f\"size: {len(data)} with {len(data.columns)} columns\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-01-23T18:49:00.835164Z",
+     "start_time": "2020-01-23T18:49:00.820614Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><strong>Dask DataFrame Structure:</strong></div>\n",
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>fare_amount</th>\n",
+       "      <th>tip_amount</th>\n",
+       "      <th>trip_distance</th>\n",
+       "      <th>pickup_longitude</th>\n",
+       "      <th>pickup_latitude</th>\n",
+       "      <th>dropoff_longitude</th>\n",
+       "      <th>dropoff_latitude</th>\n",
+       "      <th>passenger_count</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>npartitions=118</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>float32</td>\n",
+       "      <td>float32</td>\n",
+       "      <td>float32</td>\n",
+       "      <td>float32</td>\n",
+       "      <td>float32</td>\n",
+       "      <td>float32</td>\n",
+       "      <td>float32</td>\n",
+       "      <td>int64</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10000000</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1170000000</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1173057926</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>\n",
+       "<div>Dask Name: assign, 710 tasks</div>"
+      ],
+      "text/plain": [
+       "Dask DataFrame Structure:\n",
+       "                fare_amount tip_amount trip_distance pickup_longitude pickup_latitude dropoff_longitude dropoff_latitude passenger_count\n",
+       "npartitions=118                                                                                                                         \n",
+       "0                   float32    float32       float32          float32         float32           float32          float32           int64\n",
+       "10000000                ...        ...           ...              ...             ...               ...              ...             ...\n",
+       "...                     ...        ...           ...              ...             ...               ...              ...             ...\n",
+       "1170000000              ...        ...           ...              ...             ...               ...              ...             ...\n",
+       "1173057926              ...        ...           ...              ...             ...               ...              ...             ...\n",
+       "Dask Name: assign, 710 tasks"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data"
    ]
   },
   {
@@ -103,60 +269,58 @@
    "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-01-14T10:45:31.792991Z",
-     "start_time": "2020-01-14T10:43:20.654114Z"
+     "end_time": "2020-01-23T18:49:00.839040Z",
+     "start_time": "2020-01-23T18:49:00.837478Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# %debug"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-01-23T19:05:13.859288Z",
+     "start_time": "2020-01-23T18:58:40.279589Z"
     }
    },
    "outputs": [
     {
-     "ename": "MemoryError",
-     "evalue": "Unable to allocate 8.74 GiB for an array with shape (1173057928,) and data type float64",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mMemoryError\u001b[0m                               Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-5-8b966c318280>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0mbenchmarks\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'mean'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m=\u001b[0m \u001b[0mbenchmark\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmean\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdata\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrepetitions\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mrepetitions\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0mbenchmarks\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'standard deviation'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m=\u001b[0m \u001b[0mbenchmark\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mstandard_deviation\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdata\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrepetitions\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mrepetitions\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 4\u001b[0;31m \u001b[0mbenchmarks\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'sum columns'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m=\u001b[0m \u001b[0mbenchmark\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msum_columns\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdata\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrepetitions\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mrepetitions\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      5\u001b[0m \u001b[0mbenchmarks\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'product columns'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m=\u001b[0m \u001b[0mbenchmark\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mproduct_columns\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdata\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrepetitions\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mrepetitions\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      6\u001b[0m \u001b[0mbenchmarks\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'arithmetic operation'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m=\u001b[0m \u001b[0mbenchmark\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcomplicated_arithmetic_operation\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdata\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrepetitions\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mrepetitions\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/SageMaker/big_data_benchmarks/notebooks/src/benchmarks_utils.py\u001b[0m in \u001b[0;36mbenchmark\u001b[0;34m(f, df, repetitions, **kwargs)\u001b[0m\n\u001b[1;32m     14\u001b[0m     \u001b[0;32mfor\u001b[0m \u001b[0mi\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mrange\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mrepetitions\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     15\u001b[0m         \u001b[0mstart_time\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtime\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtime\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 16\u001b[0;31m         \u001b[0mret\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mf\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     17\u001b[0m         \u001b[0mtimes\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mappend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtime\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtime\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m-\u001b[0m\u001b[0mstart_time\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     18\u001b[0m     \u001b[0;32mreturn\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmean\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtimes\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/SageMaker/big_data_benchmarks/notebooks/src/dask_utils.py\u001b[0m in \u001b[0;36msum_columns\u001b[0;34m(df)\u001b[0m\n\u001b[1;32m     13\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     14\u001b[0m \u001b[0;32mdef\u001b[0m \u001b[0msum_columns\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdf\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 15\u001b[0;31m     \u001b[0;32mreturn\u001b[0m \u001b[0mdd\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcompute\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdf\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfare_amount\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0mdf\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtrip_distance\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     16\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     17\u001b[0m \u001b[0;32mdef\u001b[0m \u001b[0mproduct_columns\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdf\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda3/envs/python3/lib/python3.6/site-packages/dask/base.py\u001b[0m in \u001b[0;36mcompute\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    435\u001b[0m     \u001b[0mpostcomputes\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0mx\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__dask_postcompute__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mx\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mcollections\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    436\u001b[0m     \u001b[0mresults\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mschedule\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdsk\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkeys\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 437\u001b[0;31m     \u001b[0;32mreturn\u001b[0m \u001b[0mrepack\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mf\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0mf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0ma\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mzip\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresults\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpostcomputes\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    438\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    439\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda3/envs/python3/lib/python3.6/site-packages/dask/base.py\u001b[0m in \u001b[0;36m<listcomp>\u001b[0;34m(.0)\u001b[0m\n\u001b[1;32m    435\u001b[0m     \u001b[0mpostcomputes\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0mx\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__dask_postcompute__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mx\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mcollections\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    436\u001b[0m     \u001b[0mresults\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mschedule\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdsk\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkeys\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 437\u001b[0;31m     \u001b[0;32mreturn\u001b[0m \u001b[0mrepack\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mf\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0mf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0ma\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mzip\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresults\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpostcomputes\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    438\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    439\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda3/envs/python3/lib/python3.6/site-packages/dask/dataframe/core.py\u001b[0m in \u001b[0;36mfinalize\u001b[0;34m(results)\u001b[0m\n\u001b[1;32m     97\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     98\u001b[0m \u001b[0;32mdef\u001b[0m \u001b[0mfinalize\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresults\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 99\u001b[0;31m     \u001b[0;32mreturn\u001b[0m \u001b[0m_concat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresults\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    100\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    101\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda3/envs/python3/lib/python3.6/site-packages/dask/dataframe/core.py\u001b[0m in \u001b[0;36m_concat\u001b[0;34m(args)\u001b[0m\n\u001b[1;32m     93\u001b[0m     \u001b[0;31m# this seems easier. TODO: don't do this.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     94\u001b[0m     \u001b[0margs2\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0mi\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mi\u001b[0m \u001b[0;32min\u001b[0m \u001b[0margs\u001b[0m \u001b[0;32mif\u001b[0m \u001b[0mlen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mi\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 95\u001b[0;31m     \u001b[0;32mreturn\u001b[0m \u001b[0margs\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0margs2\u001b[0m \u001b[0;32melse\u001b[0m \u001b[0mmethods\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mconcat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0margs2\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0muniform\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     96\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     97\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda3/envs/python3/lib/python3.6/site-packages/dask/dataframe/methods.py\u001b[0m in \u001b[0;36mconcat\u001b[0;34m(dfs, axis, join, uniform, filter_warning)\u001b[0m\n\u001b[1;32m    354\u001b[0m         \u001b[0mfunc\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mconcat_dispatch\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdispatch\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtype\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdfs\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    355\u001b[0m         return func(\n\u001b[0;32m--> 356\u001b[0;31m             \u001b[0mdfs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0maxis\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0maxis\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mjoin\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mjoin\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0muniform\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0muniform\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfilter_warning\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfilter_warning\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    357\u001b[0m         )\n\u001b[1;32m    358\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda3/envs/python3/lib/python3.6/site-packages/dask/dataframe/methods.py\u001b[0m in \u001b[0;36mconcat_pandas\u001b[0;34m(dfs, axis, join, uniform, filter_warning)\u001b[0m\n\u001b[1;32m    479\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mfilter_warning\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    480\u001b[0m                 \u001b[0mwarnings\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msimplefilter\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"ignore\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mFutureWarning\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 481\u001b[0;31m             \u001b[0mout\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpd\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mconcat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdfs2\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mjoin\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mjoin\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mconcat_kwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    482\u001b[0m     \u001b[0;31m# Re-add the index if needed\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    483\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mind\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda3/envs/python3/lib/python3.6/site-packages/pandas/core/reshape/concat.py\u001b[0m in \u001b[0;36mconcat\u001b[0;34m(objs, axis, join, join_axes, ignore_index, keys, levels, names, verify_integrity, sort, copy)\u001b[0m\n\u001b[1;32m    227\u001b[0m                        \u001b[0mverify_integrity\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mverify_integrity\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    228\u001b[0m                        copy=copy, sort=sort)\n\u001b[0;32m--> 229\u001b[0;31m     \u001b[0;32mreturn\u001b[0m \u001b[0mop\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_result\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    230\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    231\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda3/envs/python3/lib/python3.6/site-packages/pandas/core/reshape/concat.py\u001b[0m in \u001b[0;36mget_result\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    391\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    392\u001b[0m                 mgr = self.objs[0]._data.concat([x._data for x in self.objs],\n\u001b[0;32m--> 393\u001b[0;31m                                                 self.new_axes)\n\u001b[0m\u001b[1;32m    394\u001b[0m                 \u001b[0mcons\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0m_concat\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_get_series_result_type\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmgr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mobjs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    395\u001b[0m                 \u001b[0;32mreturn\u001b[0m \u001b[0mcons\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmgr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__finalize__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmethod\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'concat'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda3/envs/python3/lib/python3.6/site-packages/pandas/core/internals/managers.py\u001b[0m in \u001b[0;36mconcat\u001b[0;34m(self, to_concat, new_axis)\u001b[0m\n\u001b[1;32m   1619\u001b[0m             \u001b[0mblocks\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0mobj\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mblocks\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mobj\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mnon_empties\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1620\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mlen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m{\u001b[0m\u001b[0mb\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdtype\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mb\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mblocks\u001b[0m\u001b[0;34m}\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1621\u001b[0;31m                 \u001b[0mnew_block\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mblocks\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mconcat_same_type\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mblocks\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1622\u001b[0m             \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1623\u001b[0m                 \u001b[0mvalues\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0mx\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvalues\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mx\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mblocks\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda3/envs/python3/lib/python3.6/site-packages/pandas/core/internals/blocks.py\u001b[0m in \u001b[0;36mconcat_same_type\u001b[0;34m(self, to_concat, placement)\u001b[0m\n\u001b[1;32m    326\u001b[0m         \"\"\"\n\u001b[1;32m    327\u001b[0m         values = self._concatenator([blk.values for blk in to_concat],\n\u001b[0;32m--> 328\u001b[0;31m                                     axis=self.ndim - 1)\n\u001b[0m\u001b[1;32m    329\u001b[0m         return self.make_block_same_class(\n\u001b[1;32m    330\u001b[0m             values, placement=placement or slice(0, len(values), 1))\n",
-      "\u001b[0;32m<__array_function__ internals>\u001b[0m in \u001b[0;36mconcatenate\u001b[0;34m(*args, **kwargs)\u001b[0m\n",
-      "\u001b[0;31mMemoryError\u001b[0m: Unable to allocate 8.74 GiB for an array with shape (1173057928,) and data type float64"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Done benchmarks on filterd data\n"
      ]
     }
    ],
    "source": [
-    "benchmarks['read_file']= benchmark(read_file, df=data, data_path=data_path, repetitions=repetitions)\n",
-    "benchmarks['mean']= benchmark(mean, data, repetitions=repetitions)\n",
-    "benchmarks['standard deviation']= benchmark(standard_deviation, data, repetitions=repetitions)\n",
-    "benchmarks['sum columns']= benchmark(sum_columns, data, repetitions=repetitions)\n",
-    "benchmarks['product columns']= benchmark(product_columns, data, repetitions=repetitions)\n",
-    "benchmarks['arithmetic operation']= benchmark(complicated_arithmetic_operation, data, repetitions=repetitions)\n",
-    "benchmarks['value counts']= benchmark(value_counts, data, repetitions=repetitions)\n",
-    "benchmarks['groupby statistics']= benchmark(groupby_statistics, data, repetitions=repetitions)\n",
-    "benchmarks['filter']= benchmark(filter_data, data, repetitions=repetitions)\n",
-    "print(f\"cleaned {gc.collect()} mb\")\n",
-    "benchmarks['join'] = benchmark(join, data, repetitions=repetitions, other=groupby_statistics(data))\n",
-    "print(f\"Done benchmarks on all data\")\n",
+    "# benchmarks['read_file']= benchmark(read_file, df=data, data_path=data_path, repetitions=repetitions)\n",
+    "# benchmarks['mean']= benchmark(mean, data, repetitions=repetitions)\n",
+    "# benchmarks['standard deviation']= benchmark(standard_deviation, data, repetitions=repetitions)\n",
+    "# benchmarks['mean of sum']= benchmark(mean_of_sum, data, repetitions=repetitions)\n",
+    "# benchmarks['mean of product']= benchmark(mean_of_product, data, repetitions=repetitions)\n",
+    "# benchmarks['mean of arithmetic operation']= benchmark(mean_of_complicated_arithmetic_operation, data, repetitions=repetitions)\n",
+    "# benchmarks['value counts']= benchmark(value_counts, data, repetitions=repetitions)\n",
+    "# benchmarks['groupby statistics']= benchmark(groupby_statistics, data, repetitions=repetitions)\n",
+    "# # benchmarks['filter']= benchmark(filter_data, data, repetitions=repetitions)\n",
+    "# print(f\"cleaned {gc.collect()} mb\")\n",
+    "# benchmarks['join'] = benchmark(join, data, repetitions=repetitions, other=groupby_statistics(data))\n",
+    "# print(f\"Done benchmarks on all data\")\n",
     "\n",
-    "# filtered\n",
-    "filterd = filter_data(data)\n",
-    "del data\n",
+    "# # filtered\n",
+    "# filterd = filter_data(data)\n",
+    "# del data\n",
     "\n",
-    "print(f\"Prepare filtered data and deleted {gc.collect()} MB\")\n",
-    "benchmarks['filtered mean'] = benchmark(mean, filterd, repetitions=repetitions)\n",
-    "benchmarks['filtered standard deviation'] = benchmark(standard_deviation, filterd, repetitions=repetitions)\n",
-    "benchmarks['filtered sum columns'] = benchmark(sum_columns , filterd, repetitions=repetitions)\n",
-    "benchmarks['filtered product_columns'] = benchmark(product_columns , filterd, repetitions=repetitions)\n",
-    "benchmarks['filtered complicated arithmetic operation'] = benchmark(complicated_arithmetic_operation, filterd, repetitions=repetitions)\n",
+    "# print(f\"Prepare filtered data and deleted {gc.collect()} MB\")\n",
+    "# benchmarks['filtered length']= benchmark(length, filterd, repetitions=repetitions)\n",
+    "# benchmarks['filtered mean'] = benchmark(mean, filterd, repetitions=repetitions)\n",
+    "# benchmarks['filtered standard deviation'] = benchmark(standard_deviation, filterd, repetitions=repetitions)\n",
+    "benchmarks['filtered mean of sum columns'] = benchmark(mean_of_sum , filterd, repetitions=repetitions)\n",
+    "benchmarks['filtered mean of product'] = benchmark(mean_of_product , filterd, repetitions=repetitions)\n",
+    "benchmarks['filtered complicated arithmetic operation'] = benchmark(mean_of_complicated_arithmetic_operation, filterd, repetitions=repetitions)\n",
     "benchmarks['filtered value counts'] = benchmark(value_counts, filterd, repetitions=repetitions)\n",
     "benchmarks['filtered groupby statistics'] = benchmark(groupby_statistics, filterd, repetitions=repetitions)\n",
     "benchmarks['filtered join'] = benchmark(join, filterd, repetitions=repetitions, other=groupby_statistics(filterd))\n",
@@ -165,30 +329,168 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-01-14T10:45:31.793975Z",
-     "start_time": "2020-01-14T10:42:20.172Z"
+     "end_time": "2020-01-23T19:05:29.215403Z",
+     "start_time": "2020-01-23T19:05:29.073722Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>dask-vaex-hdf5</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>read_file</th>\n",
+       "      <td>0.013979</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mean</th>\n",
+       "      <td>18.139587</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>standard deviation</th>\n",
+       "      <td>22.002922</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mean of sum</th>\n",
+       "      <td>19.942463</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mean of product</th>\n",
+       "      <td>19.711409</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mean of arithmetic operation</th>\n",
+       "      <td>37.855273</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>value counts</th>\n",
+       "      <td>21.450876</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>groupby statistics</th>\n",
+       "      <td>39.683780</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>join</th>\n",
+       "      <td>28.438838</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>filtered length</th>\n",
+       "      <td>44.254535</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>filtered mean</th>\n",
+       "      <td>46.273638</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>filtered standard deviation</th>\n",
+       "      <td>47.739374</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>filtered mean of sum columns</th>\n",
+       "      <td>49.033288</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>filtered mean of product</th>\n",
+       "      <td>47.070371</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>filtered complicated arithmetic operation</th>\n",
+       "      <td>60.981033</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>filtered value counts</th>\n",
+       "      <td>47.169167</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>filtered groupby statistics</th>\n",
+       "      <td>65.581208</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>filtered join</th>\n",
+       "      <td>55.925905</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                           dask-vaex-hdf5\n",
+       "read_file                                        0.013979\n",
+       "mean                                            18.139587\n",
+       "standard deviation                              22.002922\n",
+       "mean of sum                                     19.942463\n",
+       "mean of product                                 19.711409\n",
+       "mean of arithmetic operation                    37.855273\n",
+       "value counts                                    21.450876\n",
+       "groupby statistics                              39.683780\n",
+       "join                                            28.438838\n",
+       "filtered length                                 44.254535\n",
+       "filtered mean                                   46.273638\n",
+       "filtered standard deviation                     47.739374\n",
+       "filtered mean of sum columns                    49.033288\n",
+       "filtered mean of product                        47.070371\n",
+       "filtered complicated arithmetic operation       60.981033\n",
+       "filtered value counts                           47.169167\n",
+       "filtered groupby statistics                     65.581208\n",
+       "filtered join                                   55.925905"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "results = get_results(benchmarks, name)\n",
     "results.to_csv(results_path)\n",
-    "results.head()"
+    "# results.head()\n",
+    "results"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-01-14T10:45:31.795081Z",
-     "start_time": "2020-01-14T10:42:20.351Z"
+     "end_time": "2020-01-23T15:23:20.646100Z",
+     "start_time": "2020-01-23T15:23:19.900994Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "The user-provided path ../results/dask_1b.csv does not exist.\r\n"
+     ]
+    }
+   ],
    "source": [
     "!aws s3 cp  ../results/dask_1b.csv s3://vaex-sagemaker-demo/benchmarks/dask_1b_results.csv "
    ]
@@ -203,9 +505,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "conda_python3",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda_python3"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -217,7 +519,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/notebooks/src/dask_utils.py
+++ b/notebooks/src/dask_utils.py
@@ -2,8 +2,18 @@ import dask.dataframe as dd
 import numpy as np
 
 
-def read_file(df=None, data_path=None):
+def read_file_parquet(df=None, data_path=None):
     return dd.read_parquet(data_path, engine='pyarrow')
+
+def read_file_vaex(df=None, data_path=None, chunksize='auto', column_names=None):
+    import vaex
+    data_path = '/data/yellow_taxi_2009_2015_f32.hdf5'
+    df = vdf = vaex.open(data_path)
+    column_names = column_names or vdf.get_column_names()
+    ddf = dd.from_array(vdf[column_names].to_dask_array(chunks=chunksize), columns=column_names)
+    # we manually add this column of a different type in
+    ddf['passenger_count'] = vdf['passenger_count'].to_dask_array(chunksize)
+    return ddf
     
 def mean(df):
     return df.fare_amount.mean().compute()
@@ -11,13 +21,13 @@ def mean(df):
 def standard_deviation(df):
     return df.fare_amount.std().compute()
 
-def sum_columns(df):
-    return dd.compute(df.fare_amount + df.trip_distance) 
+def mean_of_sum(df):
+    return (df.fare_amount + df.trip_distance).mean().compute()
 
-def product_columns(df):
-    return dd.compute(df.fare_amount * df.trip_distance)
+def mean_of_product(df):
+    return (df.fare_amount * df.trip_distance).mean().compute()
 
-def complicated_arithmetic_operation(df):
+def mean_of_complicated_arithmetic_operation(df):
     theta_1 = df.pickup_longitude
     phi_1 = df.pickup_latitude
     theta_2 = df.dropoff_longitude
@@ -25,7 +35,7 @@ def complicated_arithmetic_operation(df):
     temp = (np.sin((theta_2-theta_1)/2*np.pi/180)**2
            + np.cos(theta_1*np.pi/180)*np.cos(theta_2*np.pi/180) * np.sin((phi_2-phi_1)/2*np.pi/180)**2)
     ret = 2 * np.arctan2(np.sqrt(temp), np.sqrt(1-temp))
-    return dd.compute(ret)
+    return ret.mean().compute()
 
 def value_counts(df):
     return df.fare_amount.value_counts().compute()
@@ -49,5 +59,7 @@ def filter_data(df):
                   (df.pickup_latitude > lat_min)    & (df.pickup_latitude < lat_max) & \
                   (df.dropoff_longitude > long_min) & (df.dropoff_longitude < long_max) & \
                   (df.dropoff_latitude > lat_min)   & (df.dropoff_latitude < lat_max)
-    df[expr_filter].compute()
     return df[expr_filter]
+
+def length(df):
+    return len(df)

--- a/notebooks/src/vaex_utils.py
+++ b/notebooks/src/vaex_utils.py
@@ -10,17 +10,13 @@ def mean(df):
 def standard_deviation(df):
     return df.fare_amount.std()
 
-def sum_columns(df):
-    df['sum'] = df.fare_amount + df.trip_distance
-    df['sum'].nop()
-    return df['sum']
+def mean_of_sum(df):
+    return (df.fare_amount + df.trip_distance).mean()
 
-def product_columns(df):
-    df['product'] = df.fare_amount * df.trip_distance
-    df['product'].nop()
-    return df['product']
+def mean_of_product(df):
+    return (df.fare_amount * df.trip_distance).mean()
 
-def complicated_arithmetic_operation(df):
+def mean_of_complicated_arithmetic_operation(df):
     theta_1 = df.pickup_longitude
     phi_1 = df.pickup_latitude
     theta_2 = df.dropoff_longitude
@@ -28,8 +24,7 @@ def complicated_arithmetic_operation(df):
     temp = (np.sin((theta_2-theta_1)/2*np.pi/180)**2
            + np.cos(theta_1*np.pi/180)*np.cos(theta_2*np.pi/180) * np.sin((phi_2-phi_1)/2*np.pi/180)**2)
     df['complicated'] = 2 * np.arctan2(np.sqrt(temp), np.sqrt(1-temp))
-    df['complicated'].nop()
-    return df['complicated']
+    return df['complicated'].mean()
 
 def value_counts(df):
     return df.passenger_count.value_counts()
@@ -52,7 +47,7 @@ def filter_data(df):
               (df.pickup_latitude > lat_min)    & (df.pickup_latitude < lat_max) & \
               (df.dropoff_longitude > long_min) & (df.dropoff_longitude < long_max) & \
               (df.dropoff_latitude > lat_min)   & (df.dropoff_latitude < lat_max)
-    ret = df[expr_filter]
-    print(ret.head(3)) # evalaute the filter
-    return ret
+    return df[expr_filter]
 
+def length(df):
+    return len(df)

--- a/notebooks/vaex.ipynb
+++ b/notebooks/vaex.ipynb
@@ -10,29 +10,31 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-01-23T19:05:59.242333Z",
+     "start_time": "2020-01-23T19:05:59.240316Z"
+    }
+   },
    "outputs": [],
    "source": [
-    "%%capture\n",
-    "!pip install vaex-core vaex-hdf5\n",
-    "!pip install -U numpy"
+    "# %%capture\n",
+    "# !pip install vaex-core vaex-hdf5\n",
+    "# !pip install -U numpy"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "download: s3://xdss-public-datasets/demos/taxi_1B.hdf5 to ../datasets/taxi_1B.hdf5g    g \n"
-     ]
+   "execution_count": 2,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-01-23T19:05:59.245740Z",
+     "start_time": "2020-01-23T19:05:59.244178Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
-    "!aws s3 cp s3://xdss-public-datasets/demos/taxi_1B.hdf5 ../datasets/taxi_1B.hdf5"
+    "# !aws s3 cp s3://xdss-public-datasets/demos/taxi_1B.hdf5 ../datasets/taxi_1B.hdf5"
    ]
   },
   {
@@ -44,8 +46,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-01-23T19:06:00.375934Z",
+     "start_time": "2020-01-23T19:05:59.249138Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -62,7 +76,8 @@
     "from src.config import repetitions\n",
     "\n",
     "name = 'vaex'\n",
-    "data_path = '../datasets/taxi_1B.hdf5'\n",
+    "# data_path = '../datasets/taxi_1B.hdf5'\n",
+    "data_path = '/data/yellow_taxi_2009_2015_f32.hdf5'\n",
     "results_path = f\"../results/{name}_1b.csv\"\n",
     "benchmarks = {}\n",
     "print(f\"test for {repetitions} repetitions\")"
@@ -77,8 +92,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
+   "execution_count": 4,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-01-23T19:06:00.395434Z",
+     "start_time": "2020-01-23T19:06:00.377304Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -97,19 +117,54 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
+   "execution_count": 5,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-01-23T19:06:00.442213Z",
+     "start_time": "2020-01-23T19:06:00.396829Z"
+    }
+   },
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'data' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-1-c5d84736ba45>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mdata\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m: name 'data' is not defined"
-     ]
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<thead>\n",
+       "<tr><th>#                                        </th><th>vendor_id  </th><th>pickup_datetime              </th><th>dropoff_datetime             </th><th>passenger_count  </th><th>payment_type  </th><th>trip_distance     </th><th>pickup_longitude  </th><th>pickup_latitude   </th><th>rate_code  </th><th>store_and_fwd_flag  </th><th>dropoff_longitude  </th><th>dropoff_latitude  </th><th>fare_amount       </th><th>surcharge  </th><th>mta_tax  </th><th>tip_amount        </th><th>tolls_amount  </th><th>total_amount      </th><th>pickup_hour  </th></tr>\n",
+       "</thead>\n",
+       "<tbody>\n",
+       "<tr><td><i style='opacity: 0.6'>0</i>            </td><td>VTS        </td><td>2009-01-04 02:52:00.000000000</td><td>2009-01-04 03:02:00.000000000</td><td>1                </td><td>CASH          </td><td>2.630000114440918 </td><td>-73.99195861816406</td><td>40.72156524658203 </td><td>nan        </td><td>nan                 </td><td>-73.99380493164062 </td><td>40.6959228515625  </td><td>8.899999618530273 </td><td>0.5        </td><td>nan      </td><td>0.0               </td><td>0.0           </td><td>9.399999618530273 </td><td>2            </td></tr>\n",
+       "<tr><td><i style='opacity: 0.6'>1</i>            </td><td>VTS        </td><td>2009-01-04 03:31:00.000000000</td><td>2009-01-04 03:38:00.000000000</td><td>3                </td><td>Credit        </td><td>4.550000190734863 </td><td>-73.98210144042969</td><td>40.736289978027344</td><td>nan        </td><td>nan                 </td><td>-73.95584869384766 </td><td>40.768028259277344</td><td>12.100000381469727</td><td>0.5        </td><td>nan      </td><td>2.0               </td><td>0.0           </td><td>14.600000381469727</td><td>3            </td></tr>\n",
+       "<tr><td><i style='opacity: 0.6'>2</i>            </td><td>VTS        </td><td>2009-01-03 15:43:00.000000000</td><td>2009-01-03 15:57:00.000000000</td><td>5                </td><td>Credit        </td><td>10.350000381469727</td><td>-74.0025863647461 </td><td>40.73974609375    </td><td>nan        </td><td>nan                 </td><td>-73.86997985839844 </td><td>40.770225524902344</td><td>23.700000762939453</td><td>0.0        </td><td>nan      </td><td>4.739999771118164 </td><td>0.0           </td><td>28.440000534057617</td><td>15           </td></tr>\n",
+       "<tr><td><i style='opacity: 0.6'>3</i>            </td><td>DDS        </td><td>2009-01-01 20:52:58.000000000</td><td>2009-01-01 21:14:00.000000000</td><td>1                </td><td>CREDIT        </td><td>5.0               </td><td>-73.9742660522461 </td><td>40.79095458984375 </td><td>nan        </td><td>nan                 </td><td>-73.9965591430664  </td><td>40.731849670410156</td><td>14.899999618530273</td><td>0.5        </td><td>nan      </td><td>3.049999952316284 </td><td>0.0           </td><td>18.450000762939453</td><td>20           </td></tr>\n",
+       "<tr><td><i style='opacity: 0.6'>4</i>            </td><td>DDS        </td><td>2009-01-24 16:18:23.000000000</td><td>2009-01-24 16:24:56.000000000</td><td>1                </td><td>CASH          </td><td>0.4000000059604645</td><td>-74.00157928466797</td><td>40.719383239746094</td><td>nan        </td><td>nan                 </td><td>-74.00837707519531 </td><td>40.7203483581543  </td><td>3.700000047683716 </td><td>0.0        </td><td>nan      </td><td>0.0               </td><td>0.0           </td><td>3.700000047683716 </td><td>16           </td></tr>\n",
+       "<tr><td>...                                      </td><td>...        </td><td>...                          </td><td>...                          </td><td>...              </td><td>...           </td><td>...               </td><td>...               </td><td>...               </td><td>...        </td><td>...                 </td><td>...                </td><td>...               </td><td>...               </td><td>...        </td><td>...      </td><td>...               </td><td>...           </td><td>...               </td><td>...          </td></tr>\n",
+       "<tr><td><i style='opacity: 0.6'>1,173,057,922</i></td><td>VTS        </td><td>2015-12-31 23:59:56.000000000</td><td>2016-01-01 00:08:18.000000000</td><td>5                </td><td>1             </td><td>1.2000000476837158</td><td>-73.99381256103516</td><td>40.72087097167969 </td><td>1.0        </td><td>0.0                 </td><td>-73.98621368408203 </td><td>40.722469329833984</td><td>7.5               </td><td>0.5        </td><td>0.5      </td><td>1.7599999904632568</td><td>0.0           </td><td>10.5600004196167  </td><td>23           </td></tr>\n",
+       "<tr><td><i style='opacity: 0.6'>1,173,057,923</i></td><td>CMT        </td><td>2015-12-31 23:59:58.000000000</td><td>2016-01-01 00:05:19.000000000</td><td>2                </td><td>2             </td><td>2.0               </td><td>-73.96527099609375</td><td>40.76028060913086 </td><td>1.0        </td><td>0.0                 </td><td>-73.93951416015625 </td><td>40.75238800048828 </td><td>7.5               </td><td>0.5        </td><td>0.5      </td><td>0.0               </td><td>0.0           </td><td>8.800000190734863 </td><td>23           </td></tr>\n",
+       "<tr><td><i style='opacity: 0.6'>1,173,057,924</i></td><td>CMT        </td><td>2015-12-31 23:59:59.000000000</td><td>2016-01-01 00:12:55.000000000</td><td>2                </td><td>2             </td><td>3.799999952316284 </td><td>-73.98729705810547</td><td>40.739078521728516</td><td>1.0        </td><td>0.0                 </td><td>-73.9886703491211  </td><td>40.69329833984375 </td><td>13.5              </td><td>0.5        </td><td>0.5      </td><td>0.0               </td><td>0.0           </td><td>14.800000190734863</td><td>23           </td></tr>\n",
+       "<tr><td><i style='opacity: 0.6'>1,173,057,925</i></td><td>VTS        </td><td>2015-12-31 23:59:59.000000000</td><td>2016-01-01 00:10:26.000000000</td><td>1                </td><td>2             </td><td>1.9600000381469727</td><td>-73.99755859375   </td><td>40.72569274902344 </td><td>1.0        </td><td>0.0                 </td><td>-74.01712036132812 </td><td>40.705322265625   </td><td>8.5               </td><td>0.5        </td><td>0.5      </td><td>0.0               </td><td>0.0           </td><td>9.800000190734863 </td><td>23           </td></tr>\n",
+       "<tr><td><i style='opacity: 0.6'>1,173,057,926</i></td><td>VTS        </td><td>2015-12-31 23:59:59.000000000</td><td>2016-01-01 00:21:30.000000000</td><td>1                </td><td>1             </td><td>1.059999942779541 </td><td>-73.9843978881836 </td><td>40.76725769042969 </td><td>1.0        </td><td>0.0                 </td><td>-73.99098205566406 </td><td>40.76057052612305 </td><td>13.5              </td><td>0.5        </td><td>0.5      </td><td>2.9600000381469727</td><td>0.0           </td><td>17.760000228881836</td><td>23           </td></tr>\n",
+       "</tbody>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "#              vendor_id    pickup_datetime                dropoff_datetime               passenger_count    payment_type    trip_distance       pickup_longitude    pickup_latitude     rate_code    store_and_fwd_flag    dropoff_longitude    dropoff_latitude    fare_amount         surcharge    mta_tax    tip_amount          tolls_amount    total_amount        pickup_hour\n",
+       "0              VTS          2009-01-04 02:52:00.000000000  2009-01-04 03:02:00.000000000  1                  CASH            2.630000114440918   -73.99195861816406  40.72156524658203   nan          nan                   -73.99380493164062   40.6959228515625    8.899999618530273   0.5          nan        0.0                 0.0             9.399999618530273   2\n",
+       "1              VTS          2009-01-04 03:31:00.000000000  2009-01-04 03:38:00.000000000  3                  Credit          4.550000190734863   -73.98210144042969  40.736289978027344  nan          nan                   -73.95584869384766   40.768028259277344  12.100000381469727  0.5          nan        2.0                 0.0             14.600000381469727  3\n",
+       "2              VTS          2009-01-03 15:43:00.000000000  2009-01-03 15:57:00.000000000  5                  Credit          10.350000381469727  -74.0025863647461   40.73974609375      nan          nan                   -73.86997985839844   40.770225524902344  23.700000762939453  0.0          nan        4.739999771118164   0.0             28.440000534057617  15\n",
+       "3              DDS          2009-01-01 20:52:58.000000000  2009-01-01 21:14:00.000000000  1                  CREDIT          5.0                 -73.9742660522461   40.79095458984375   nan          nan                   -73.9965591430664    40.731849670410156  14.899999618530273  0.5          nan        3.049999952316284   0.0             18.450000762939453  20\n",
+       "4              DDS          2009-01-24 16:18:23.000000000  2009-01-24 16:24:56.000000000  1                  CASH            0.4000000059604645  -74.00157928466797  40.719383239746094  nan          nan                   -74.00837707519531   40.7203483581543    3.700000047683716   0.0          nan        0.0                 0.0             3.700000047683716   16\n",
+       "...            ...          ...                            ...                            ...                ...             ...                 ...                 ...                 ...          ...                   ...                  ...                 ...                 ...          ...        ...                 ...             ...                 ...\n",
+       "1,173,057,922  VTS          2015-12-31 23:59:56.000000000  2016-01-01 00:08:18.000000000  5                  1               1.2000000476837158  -73.99381256103516  40.72087097167969   1.0          0.0                   -73.98621368408203   40.722469329833984  7.5                 0.5          0.5        1.7599999904632568  0.0             10.5600004196167    23\n",
+       "1,173,057,923  CMT          2015-12-31 23:59:58.000000000  2016-01-01 00:05:19.000000000  2                  2               2.0                 -73.96527099609375  40.76028060913086   1.0          0.0                   -73.93951416015625   40.75238800048828   7.5                 0.5          0.5        0.0                 0.0             8.800000190734863   23\n",
+       "1,173,057,924  CMT          2015-12-31 23:59:59.000000000  2016-01-01 00:12:55.000000000  2                  2               3.799999952316284   -73.98729705810547  40.739078521728516  1.0          0.0                   -73.9886703491211    40.69329833984375   13.5                0.5          0.5        0.0                 0.0             14.800000190734863  23\n",
+       "1,173,057,925  VTS          2015-12-31 23:59:59.000000000  2016-01-01 00:10:26.000000000  1                  2               1.9600000381469727  -73.99755859375     40.72569274902344   1.0          0.0                   -74.01712036132812   40.705322265625     8.5                 0.5          0.5        0.0                 0.0             9.800000190734863   23\n",
+       "1,173,057,926  VTS          2015-12-31 23:59:59.000000000  2016-01-01 00:21:30.000000000  1                  1               1.059999942779541   -73.9843978881836   40.76725769042969   1.0          0.0                   -73.99098205566406   40.76057052612305   13.5                0.5          0.5        2.9600000381469727  0.0             17.760000228881836  23"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -118,52 +173,49 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
+   "execution_count": 7,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-01-23T19:10:11.211538Z",
+     "start_time": "2020-01-23T19:08:23.153301Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  #  vendor_id    pickup_datetime                dropoff_datetime                 passenger_count  payment_type      trip_distance    pickup_longitude    pickup_latitude    rate_code    store_and_fwd_flag    dropoff_longitude    dropoff_latitude    fare_amount    surcharge    mta_tax    tip_amount    tolls_amount    total_amount    pickup_hour    sum    product    complicated\n",
-      "  0  VTS          2009-01-04 02:52:00.000000000  2009-01-04 03:02:00.000000000                  1  CASH                       2.63            -73.992             40.7216          nan                   nan             -73.9938             40.6959            8.9          0.5        nan          0                  0            9.4               2    9.9        8.9    0.000127551\n",
-      "  1  VTS          2009-01-04 03:31:00.000000000  2009-01-04 03:38:00.000000000                  3  Credit                     4.55            -73.9821            40.7363          nan                   nan             -73.9558             40.768            12.1          0.5        nan          2                  0           14.6               3   15.1       36.3    0.000483058\n",
-      "  2  VTS          2009-01-03 15:43:00.000000000  2009-01-03 15:57:00.000000000                  5  Credit                    10.35            -74.0026            40.7397          nan                   nan             -73.87               40.7702           23.7          0          nan          4.74               0           28.44             15   28.7      118.5    0.0023191\n",
-      "cleaned 4579 mb\n",
-      "Done benchmarks on all data\n",
-      "  #  vendor_id    pickup_datetime                dropoff_datetime                 passenger_count  payment_type      trip_distance    pickup_longitude    pickup_latitude    rate_code    store_and_fwd_flag    dropoff_longitude    dropoff_latitude    fare_amount    surcharge    mta_tax    tip_amount    tolls_amount    total_amount    pickup_hour    sum    product    complicated\n",
-      "  0  VTS          2009-01-04 02:52:00.000000000  2009-01-04 03:02:00.000000000                  1  CASH                       2.63            -73.992             40.7216          nan                   nan             -73.9938             40.6959            8.9          0.5        nan          0                  0            9.4               2    9.9        8.9    0.000127551\n",
-      "  1  VTS          2009-01-04 03:31:00.000000000  2009-01-04 03:38:00.000000000                  3  Credit                     4.55            -73.9821            40.7363          nan                   nan             -73.9558             40.768            12.1          0.5        nan          2                  0           14.6               3   15.1       36.3    0.000483058\n",
-      "  2  VTS          2009-01-03 15:43:00.000000000  2009-01-03 15:57:00.000000000                  5  Credit                    10.35            -74.0026            40.7397          nan                   nan             -73.87               40.7702           23.7          0          nan          4.74               0           28.44             15   28.7      118.5    0.0023191\n",
-      "Prepare filtered data and deleted 4165 MB\n",
+      "Prepare filtered data and deleted 20 MB\n",
       "Done benchmarks on filterd data\n"
      ]
     }
    ],
    "source": [
-    "benchmarks['read_file']= benchmark(read_file, df=data, data_path=data_path, repetitions=repetitions)\n",
-    "benchmarks['mean']= benchmark(mean, data, repetitions=repetitions)\n",
-    "benchmarks['standard deviation']= benchmark(standard_deviation, data, repetitions=repetitions)\n",
-    "benchmarks['sum columns']= benchmark(sum_columns, data, repetitions=repetitions)\n",
-    "benchmarks['product columns']= benchmark(product_columns, data, repetitions=repetitions)\n",
-    "benchmarks['arithmetic operation']= benchmark(complicated_arithmetic_operation, data, repetitions=repetitions)\n",
-    "benchmarks['value counts']= benchmark(value_counts, data, repetitions=repetitions)\n",
-    "benchmarks['groupby statistics']= benchmark(groupby_statistics, data, repetitions=repetitions)\n",
-    "benchmarks['filter']= benchmark(filter_data, data, repetitions=repetitions)\n",
-    "print(f\"cleaned {gc.collect()} mb\")\n",
-    "benchmarks['join'] = benchmark(join, data, repetitions=repetitions, other=groupby_statistics(data))\n",
-    "print(f\"Done benchmarks on all data\")\n",
+    "# benchmarks['read_file']= benchmark(read_file, df=data, data_path=data_path, repetitions=repetitions)\n",
+    "# benchmarks['length'] = benchmark(length, data, repetitions=repetitions)\n",
+    "# benchmarks['mean']= benchmark(mean, data, repetitions=repetitions)\n",
+    "# benchmarks['standard deviation']= benchmark(standard_deviation, data, repetitions=repetitions)\n",
+    "# benchmarks['mean of sum']= benchmark(mean_of_sum, data, repetitions=repetitions)\n",
+    "# benchmarks['mean of columns']= benchmark(mean_of_product, data, repetitions=repetitions)\n",
+    "# benchmarks['mean of complicated arithmetic operation']= benchmark(mean_of_complicated_arithmetic_operation, data, repetitions=repetitions)\n",
+    "# benchmarks['value counts']= benchmark(value_counts, data, repetitions=repetitions)\n",
+    "# benchmarks['groupby statistics']= benchmark(groupby_statistics, data, repetitions=repetitions)\n",
+    "# # benchmarks['filter']= benchmark(filter_data, data, repetitions=repetitions)\n",
+    "# print(f\"cleaned {gc.collect()} mb\")\n",
+    "# benchmarks['join'] = benchmark(join, data, repetitions=repetitions, other=groupby_statistics(data))\n",
+    "# print(f\"Done benchmarks on all data\")\n",
     "\n",
     "# filtered\n",
     "filterd = filter_data(data)\n",
     "del data\n",
     "\n",
     "print(f\"Prepare filtered data and deleted {gc.collect()} MB\")\n",
+    "benchmarks['filtered length'] = benchmark(length, filterd, repetitions=repetitions)\n",
     "benchmarks['filtered mean'] = benchmark(mean, filterd, repetitions=repetitions)\n",
     "benchmarks['filtered standard deviation'] = benchmark(standard_deviation, filterd, repetitions=repetitions)\n",
-    "benchmarks['filtered sum columns'] = benchmark(sum_columns , filterd, repetitions=repetitions)\n",
-    "benchmarks['filtered product_columns'] = benchmark(product_columns , filterd, repetitions=repetitions)\n",
-    "benchmarks['filtered complicated arithmetic operation'] = benchmark(complicated_arithmetic_operation, filterd, repetitions=repetitions)\n",
+    "benchmarks['filtered mean of sum'] = benchmark(mean_of_sum , filterd, repetitions=repetitions)\n",
+    "benchmarks['filtered mean of product'] = benchmark(mean_of_product , filterd, repetitions=repetitions)\n",
+    "benchmarks['filtered complicated arithmetic operation'] = benchmark(mean_of_complicated_arithmetic_operation, filterd, repetitions=repetitions)\n",
     "benchmarks['filtered value counts'] = benchmark(value_counts, filterd, repetitions=repetitions)\n",
     "benchmarks['filtered groupby statistics'] = benchmark(groupby_statistics, filterd, repetitions=repetitions)\n",
     "benchmarks['filtered join'] = benchmark(join, filterd, repetitions=repetitions, other=groupby_statistics(filterd))\n",
@@ -172,91 +224,59 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>vaex</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>read_file</th>\n",
-       "      <td>0.009607</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>mean</th>\n",
-       "      <td>1.157343</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>standard deviation</th>\n",
-       "      <td>2.813296</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>sum columns</th>\n",
-       "      <td>0.708558</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>product columns</th>\n",
-       "      <td>0.659668</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                        vaex\n",
-       "read_file           0.009607\n",
-       "mean                1.157343\n",
-       "standard deviation  2.813296\n",
-       "sum columns         0.708558\n",
-       "product columns     0.659668"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-01-23T19:07:06.663171Z",
+     "start_time": "2020-01-23T19:05:57.572Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "results = get_results(benchmarks, name)\n",
     "results.to_csv(results_path)\n",
-    "results.head()"
+    "results#.head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "upload: ../results/vaex_1b.csv to s3://vaex-sagemaker-demo/benchmarks/vaex_1b_results.csv\n"
-     ]
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-01-23T19:07:06.664117Z",
+     "start_time": "2020-01-23T19:05:57.574Z"
     }
-   ],
+   },
+   "outputs": [],
+   "source": [
+    "total = results[name].sum()\n",
+    "print(f'{int(total / 60)} min {total % 60:.1f} seconds')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-01-23T19:07:06.664913Z",
+     "start_time": "2020-01-23T19:05:57.575Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "res"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-01-23T19:07:06.665692Z",
+     "start_time": "2020-01-23T19:05:57.576Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "!aws s3 cp  ../results/vaex_1b.csv s3://vaex-sagemaker-demo/benchmarks/vaex_1b_results.csv "
    ]
@@ -271,9 +291,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "conda_python3",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda_python3"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -285,7 +305,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This is a bit of a better comparison and makes dask run. Instead of materializing a column, we nog aggregate (take the mean). And we don't ask dask to materialize the filtered dataframe.
These are my result using vaex-hdf5 (parquet is much slower):
![image](https://user-images.githubusercontent.com/1765949/73016171-a3b8ea80-3e1d-11ea-88b1-39acee451ebc.png)

And vaex:
![image](https://user-images.githubusercontent.com/1765949/73016196-ae737f80-3e1d-11ea-8849-a6df1af2af87.png)
